### PR TITLE
Fix scheduled event cleanup on deactivate

### DIFF
--- a/woodmart-child/includes/Core/Installer.php
+++ b/woodmart-child/includes/Core/Installer.php
@@ -29,6 +29,8 @@ class Installer {
 	public static function deactivate() {
 		error_log( 'WoodmartChildRPG Installer: Deactivate hook called.' ); // DEBUG
 		wp_clear_scheduled_hook( 'wcrpg_assign_elf_items_weekly_event' );
+		wp_clear_scheduled_hook( 'wcrpg_issue_weekly_human_coupon_event' );
+		wp_clear_scheduled_hook( 'wcrpg_cleanup_rpg_coupons_event' );
 		flush_rewrite_rules();
 		error_log( 'WoodmartChildRPG Installer: Deactivation complete.' ); // DEBUG
 	}


### PR DESCRIPTION
## Summary
- ensure all scheduled hooks are cleared when the plugin is deactivated

## Testing
- `php -l woodmart-child/includes/Core/Installer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b7184de4832d88f8a4bd58a3ab25